### PR TITLE
Update to Enigo 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [workspace.package]
 version = "0.1.1"
-edition = "2021"
-rust-version = "1.77"
+edition = "2024"
+rust-version = "1.85.1"
 repository = "https://github.com/rs017991/g11-macro"
 authors = ["Ryan Scheidter <ryan.scheidter@gmail.com>"]
 keywords = ["g11", "logitech", "keyboard"]
 license = "MIT"
 
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
 	# Library
 	"g11-macro-keys",
@@ -20,7 +20,7 @@ members = [
 
 [workspace.dependencies]
 hidapi = "2.6"
-enigo = { version = "0.3.*", default-features = false }
+enigo = { version = "0.5.*", default-features = false }
 xdg = "3.0"
 
 log = { version = "0.4.*" }

--- a/g11-macro-daemon/CONFIGURATION.md
+++ b/g11-macro-daemon/CONFIGURATION.md
@@ -35,7 +35,7 @@ KeyBinding(
 Note that when scripting modifier keys like Control/Shift/etc., you should include a step for each to be released at the end.
 
 While keystrokes are the most obvious candidates for steps in your script,
-you may include any type of [Enigo Token](https://docs.rs/enigo/0.3.0/enigo/agent/enum.Token.html). For example:
+you may include any type of [Enigo Token](https://docs.rs/enigo/0.5.*/enigo/agent/enum.Token.html). For example:
 ```ron
 KeyBinding(
     m: 2,

--- a/g11-macro-daemon/INSTALLATION.md
+++ b/g11-macro-daemon/INSTALLATION.md
@@ -11,7 +11,8 @@ Others ought to work just fine, so long as you can locate the respective package
 ### Debian
 Tested on Linux Mint 22.1 (Ubuntu 24.04):
 ```bash
-sudo apt install cargo libudev-dev
+sudo apt install rustup libudev-dev
+rustup default stable
 ```
 
 ### Fedora
@@ -74,6 +75,10 @@ it makes more sense to run this as a daemon.
 
 
 ## Appendix: Troubleshooting
+* If your version of Rust is too old, yet is not convenient for you to upgrade, you may try installing an older version of the daemon:
+  ```bash
+  cargo install g11-macro-daemon --version '0.1.*'
+  ```
 * You can check the status of the service by running:
   ```bash
   systemctl --user status g11-macro-daemon


### PR DESCRIPTION
Fixes #5 

* Allows wider selection of Keys for use in macros
* Includes necessary MSRV bump to 1.85.1